### PR TITLE
Removed dependency for Content-Length header

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -197,16 +197,12 @@ class UserHelper
 
 	def self._check_update_headers!(headers)
 		content_type = headers[:content_type]
-		content_length = headers[:content_length]
 
 		if !content_type.nil?
 			if !content_type.include?('text/plain') && !content_type.include?('text/html')
 				raise 'text/plain or text/html file required'
 			end
 		end
-
-		raise 'content-length header required' if content_length.nil?
-		raise 'max update size is 1mb' if content_length.to_i > 1024 * 1024
 	end
 
 


### PR DESCRIPTION
Because otherwise all cloudflare hosted/proxied sites (like mine for instance https://dracoblue.net/twtxt.txt) won't work.

See https://support.cloudflare.com/hc/en-us/articles/200168386-Why-is-my-dynamic-content-being-sent-with-chunked-encoding- for more Information.
